### PR TITLE
Always report execution_count in execution_reply

### DIFF
--- a/src/jupyter/messages/shell.rs
+++ b/src/jupyter/messages/shell.rs
@@ -33,6 +33,8 @@ pub enum ShellReply {
         #[serde(rename = "evalue")]
         value: String,
         traceback: Vec<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        execution_count: Option<usize>,
     },
 }
 


### PR DESCRIPTION
Hi, thanks for this cool project! I wanted to use Zed's REPL mode with this kernel, and it mostly works but I ran into a small problem after these steps:

1. Attempt to evaluate an incomplete / broken cell (i.e. cause a parse failure), e.g. 
	```nu
    # %%
	ls |
	```
2. After the (expected) error is displayed, fix it and attempt to run the cell again

At this point, the missing field was resulting in Zed failing with a message like this:
```
ERROR [repl::kernels::native_kernel] kernel: handling failed for shell task: Error deserializing content for msg_type `execute_reply`: missing field `execution_count`

Caused by:
    missing field `execution_count`
```

I believe this is because the [`ExecutionCount`](https://docs.rs/jupyter-protocol/1.0.0/jupyter_protocol/struct.ExecutionCount.html) that Zed's client uses is expected to be present + non-null, which seems to be in line with the [protocol docs](https://jupyter-client.readthedocs.io/en/stable/messaging.html#request-reply), but this kernel was omitting it for error cases.

Once this state occurred it required a kernel restart to fix it, but since applying this change I haven't been able to reproduce the issue anymore!